### PR TITLE
feat(users): add data grid component for users page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import Layout from './components/Layout/Layout';
 import BoardPage from './pages/Board/Board';
 import Dashboard from './pages/Dashboard/Dashboard';
 import Calendar from "./pages/Calendar/Calendar";
+import DataGrid from "./pages/DataGrid/DataGrid";
 
 const App = () => {
   return <div id="dashboard">
@@ -12,7 +13,7 @@ const App = () => {
           <Route path="dashboard" element={<Dashboard />} />
           <Route path="calendar" element={<Calendar />} />
           <Route path="board" element={<BoardPage />} />
-          <Route path="users" element={<h1>Users</h1>} />
+          <Route path="users" element={<DataGrid />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/pages/DataGrid/DataGrid.css
+++ b/src/pages/DataGrid/DataGrid.css
@@ -1,0 +1,13 @@
+.table-container {
+    padding: 3rem 5rem;
+}
+
+.table-container>:nth-child(1)
+{
+    border-radius: 10px!important;
+    overflow: hidden!important;
+}
+
+.MuiTableRow-root, .MuiTableCell-root{
+    border: none!important;
+}

--- a/src/pages/DataGrid/DataGrid.jsx
+++ b/src/pages/DataGrid/DataGrid.jsx
@@ -1,0 +1,48 @@
+import React, { useMemo } from 'react';
+import { MaterialReactTable } from 'material-react-table';
+import { userData } from '../../data';
+import './DataGrid.css';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+
+const DataGrid = () => {
+
+    const columns = useMemo(() => [
+        {
+            accessorKey: "name.firstName",
+            header: 'First Name',
+        },
+        {
+            accessorKey: "name.lastName",
+            header: 'Last Name',
+        },
+        {
+            accessorKey: "address", //normal accessorKey
+            header: "Address",
+        },
+        {
+            accessorKey: "city",
+            header: "City",
+        },
+        {
+            accessorKey: "state",
+            header: "State",
+        },
+    ])
+    const theme = useMemo(
+        () => createTheme({
+            palette: {
+                mode: "dark"
+            }
+        })
+    )
+
+    return (
+        <div className="table-container">
+            <ThemeProvider theme={theme}>
+                <MaterialReactTable columns={columns} data={userData} />
+            </ThemeProvider>
+        </div>
+    )
+}
+
+export default DataGrid;


### PR DESCRIPTION
Implement a new DataGrid component using MaterialReactTable to display user data in a tabular format. Includes styling and dark theme support.